### PR TITLE
Fix version file URL property

### DIFF
--- a/DuoPods.version
+++ b/DuoPods.version
@@ -1,6 +1,6 @@
 {
 	"NAME":"DuoPods",
-	"URL":            "https://raw.githubusercontent.com/zer0Kerbal/DuoPods/DuoPods.version",
+	"URL":            "https://raw.githubusercontent.com/zer0Kerbal/DuoPods/master/DuoPods.version",
 	"DOWNLOAD":       "https://github.com/zer0Kerbal/DuoPods/releases/latest",
 	"CHANGE_LOG_URL": "https://raw.githubusercontent.com/zer0Kerbal/DuoPods/master/Changelog.cfg",
     "GITHUB":

--- a/GameData/DuoPods/DuoPods.version
+++ b/GameData/DuoPods/DuoPods.version
@@ -1,6 +1,6 @@
 {
 	"NAME":"DuoPods",
-	"URL":            "https://raw.githubusercontent.com/zer0Kerbal/DuoPods/DuoPods.version",
+	"URL":            "https://raw.githubusercontent.com/zer0Kerbal/DuoPods/master/DuoPods.version",
 	"DOWNLOAD":       "https://github.com/zer0Kerbal/DuoPods/releases/latest",
 	"CHANGE_LOG_URL": "https://raw.githubusercontent.com/zer0Kerbal/DuoPods/master/Changelog.cfg",
     "GITHUB":


### PR DESCRIPTION
The URL property is a 404 currently.
Now it's fixed.

Tagging @zer0Kerbal to encourage GitHub to send a notification.

https://github.com/DasSkelett/AVC-VersionFileValidator   &larr; nice tool by @DasSkelett!